### PR TITLE
Support content negotiation on URL download

### DIFF
--- a/lib/ShExLoader.js
+++ b/lib/ShExLoader.js
@@ -11,7 +11,7 @@ var Jsonld = require("jsonld");
 
 /* Helper function to read from filesystem or web.
  */
-function GET (f) {
+function GET (f, mediaType) {
   var m;
   return f === "-" ?
     new Promise(function (fulfill, reject) {
@@ -33,7 +33,10 @@ function GET (f) {
       });
     }) : (f.match("^[a-z]+://.") && !f.match("^file://.")) ?
     // Read from http or whatever Request handles.
-    Request(f).then(function (text) {
+    Request(mediaType ? {
+	  uri: f,
+	  headers: { Accept: mediaType }
+	} : f).then(function (text) {
       return {text: text, url: f};
     }) : (m = f.match("^data:([^,]+),(.*)$")) ?
     // Read from data: URL
@@ -55,9 +58,9 @@ function GET (f) {
   });
 }
 
-function loadList (list, done) {
+function loadList (list, mediaType, done) {
   return list.map(function (p) {
-    return GET(p).then(function (loaded) {
+    return GET(p, mediaType).then(function (loaded) {
       return done(loaded.text, loaded.url);
     });
   });
@@ -76,7 +79,7 @@ function LoadPromise (shex, json, turtle, jsonld, schemaOptions, dataOptions) {
   var promises = [];
 
   function add (src, metaList, mediaType, f, target, options) {
-    return loadList(src, function (text, url) {
+    return loadList(src, mediaType, function (text, url) {
       var meta = {mediaType: mediaType, url: url, base: url, prefixes: {}};
       metaList.push(meta);
       return new Promise(function (resolve, reject) {


### PR DESCRIPTION
When downloading data, we can now send an `Accept` header specifying the content types we support; the remote end can adapt to this header and send the right format. For instance, Wikidata’s entity IRIs (e. g. http://www.wikidata.org/entity/Q42) return JSON by default, but Turtle when requested with `Accept: text/turtle`, so this change makes it possible to use those IRIs for `bin/validate`’s `-d` option.

The `GET` function gains a second parameter, which is optional; omitting it results in the old behavior. The `loadList` function signature changes in an incompatible way, but that function is not exported.

---

Note: Tests fail for me both with and without this change, so it would be great if someone else could test this.