### PR TITLE
~ set foreground color when changing background color

### DIFF
--- a/doc/shex-simple.html
+++ b/doc/shex-simple.html
@@ -32,10 +32,10 @@
       .running { background-color: #ddf; }
       #inputarea { overflow-x: none; white-space:nowrap; }
       #inputarea textarea { overflow-x: auto }
-      .schema.textarea, .schema, .schema.ui-dialog-content { background-color: #f4f4ff; border-color: #fc561c }
-      #inputSchema li.selected button { background-color: #e8e8ff; }
-      #inputData textarea, .data, .data.ui-dialog-content { background-color: #f4fff4; border-color: #f0a133 }
-      #inputData li.selected button { background-color: #e8ffe8; }
+      .schema.textarea, .schema, .schema.ui-dialog-content { background-color: #f4f4ff; color: #000000; border-color: #fc561c }
+      #inputSchema li.selected button { background-color: #e8e8ff; color: #000000; }
+      #inputData textarea, .data, .data.ui-dialog-content { background-color: #f4fff4; color: #000000; border-color: #f0a133 }
+      #inputData li.selected button { background-color: #e8ffe8; color: #000000; }
       #manifestDrop { border-color: white; width: 100%; }
       #manifestDrop div.manifest { overflow: auto; max-height: 10ex; }
       #inputSchema li button, #inputData li button {


### PR DESCRIPTION
Some Browser themes select a dark background color and a light foreground color by default; if we set the backround color to light, but don’t set the foreground color as well, then the resulting light-on-light combination can be almost unreadable.