### PR TITLE
~ fix depth counting in emptyTracker

### DIFF
--- a/browser/shex-browserify.js
+++ b/browser/shex-browserify.js
@@ -4357,8 +4357,8 @@ function ShExValidator_constructor(schema, options) {
     return {
       recurse: noop,
       known: noop,
-      enter: (point, label) => { ++this.depth; },
-      exit: (point, label, ret) => { --this.depth; },
+      enter: function (point, label) { ++this.depth; },
+      exit: function (point, label, ret) { --this.depth; },
       depth: 0
     };
   };

--- a/lib/ShExValidator.js
+++ b/lib/ShExValidator.js
@@ -293,8 +293,8 @@ function ShExValidator_constructor(schema, options) {
     return {
       recurse: noop,
       known: noop,
-      enter: (point, label) => { ++this.depth; },
-      exit: (point, label, ret) => { --this.depth; },
+      enter: function (point, label) { ++this.depth; },
+      exit: function (point, label, ret) { --this.depth; },
       depth: 0
     };
   };


### PR DESCRIPTION
Arrow functions do not have their own `this`: using `this` in them always refers to the `this` of the containing scope. To write a method of an object, and refer to the `depth` of the tracker instead of that of
the surrounding `ShExValidator_constructor` (which is `undefined`), ordinary functions must be used. See also [MDN][1].

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#Arrow_functions_used_as_methods