### PR TITLE
Add placeholder for shape map input

### DIFF
--- a/packages/shex-webapp/doc/shex-simple.html
+++ b/packages/shex-webapp/doc/shex-simple.html
@@ -317,7 +317,7 @@ ul {
                 <li><a href="#fixedMap-tab">Fixed Map</a></li>
               </ul>
               <!-- <div id="textMap-tab"> -->
-                <textarea id="textMap" style="width:100%; height:100%;"></textarea>
+                <textarea id="textMap" style="width:100%; height:100%;" placeholder="&lt;SomeFocusNode&gt;@START"></textarea>
               <!-- </div> -->
               <div id="editMap-tab">
                 <table id="editMap" data-dirty="false" style="width:100%;">

--- a/packages/shex-webapp/doc/shex-simple.js
+++ b/packages/shex-webapp/doc/shex-simple.js
@@ -1620,6 +1620,7 @@ function loadSearchParameters () {
   }
   if ("textMapIsSparqlQuery" in iface) {
     $("#textMap").data("isSparqlQuery", true)
+      .attr("placeholder", "SELECT ?id WHERE {\n    # ...\n}");
   }
 
   // Load all known query parameters.


### PR DESCRIPTION
We define a standard placeholder in the HTML with a very simple shape map, and override it with a SPARQL query if the option to directly use a SPARQL query as the shape map is set.

Part of [T221611](https://phabricator.wikimedia.org/T221611).