### PR TITLE
Focus shape map input if appropriate

### DIFF
--- a/packages/shex-webapp/doc/shex-simple.js
+++ b/packages/shex-webapp/doc/shex-simple.js
@@ -1699,6 +1699,9 @@ function loadSearchParameters () {
          iface.schema.reduce((r, elt) => { return r+elt.length; }, 0))
        && shapeMapErrors.length === 0) {
       callValidator();
+      if (!hasFocusNode()) {
+        $("#textMap").focus();
+      }
     }
   });
 }


### PR DESCRIPTION
If we’re otherwise ready to validate already (i. e. a schema and data have been prepared via the URL), move the browser focus to the shape map input if that’s still missing.

Part of [T221611](https://phabricator.wikimedia.org/T221611).