### PR TITLE
Hide “Manifest:” text if there are no manifests

### DIFF
--- a/packages/shex-webapp/doc/shex-simple.html
+++ b/packages/shex-webapp/doc/shex-simple.html
@@ -46,7 +46,7 @@
       #inputData textarea, .data, .data.ui-dialog-content { background-color: #f4fff4; color: #000000; border-color: #f0a133 }
       #inputData li.selected button { background-color: #e8ffe8; color: #000000; }
       #manifestDrop { border-color: white; width: 100%; }
-      #manifestDrop div.manifest { overflow: auto; max-height: 10ex; }
+      #manifestDrop div.manifest { overflow: auto; max-height: 12ex; }
       #inputSchema li button, #inputData li button {
         font-size: .7em;
         padding: 0em 2ex;
@@ -301,8 +301,8 @@ ul {
         <textarea rows="25" class="schema droparea" style="width: 100%"></textarea>
         <div>
           <div id="manifestDrop" class="droparea">
-            <p>Manifest:</p>
             <div class="manifest">
+              <p>Manifest:</p>
               <ul>
                 <li>Javascript is disabled or slow to load or something went a bit pear-shaped.</li>
               </ul>

--- a/packages/shex-webapp/doc/shex-simple.js
+++ b/packages/shex-webapp/doc/shex-simple.js
@@ -1964,6 +1964,7 @@ function prepareManifest (demoList, base) {
   }, {});
   var nestingAsList = Object.keys(nesting).map(e => nesting[e]);
   paintManifest("#inputSchema .manifest ul", nestingAsList, pickSchema, listItems, "inputSchema");
+  $("#inputSchema .manifest").css("visibility", nestingAsList.length > 0 ? "visible" : "hidden");
   var timeouts = Object.keys(Caches).reduce((acc, k) => {
     acc[k] = undefined;
     return acc;


### PR DESCRIPTION
If no manifests were loaded (e. g. because `&manifest=[]` was specified in the URL), also hide the “Manifest:” text, because it doesn’t make much sense to display it over an empty list.

To do this, the “Manifest:” text is moved into the `div.manifest`, which requires its `max-height` to be bumped slightly. The visibility of the surrounding `#manifestDrop.droparea` isn’t changed, so that drag’n’drop of manifest JSON files still works (the “Manifest:” text is shown again in that event).