### PR TITLE
Rename and remove query input tabs in shex simple tool

### DIFF
--- a/packages/shex-webapp/doc/shex-simple.html
+++ b/packages/shex-webapp/doc/shex-simple.html
@@ -305,9 +305,8 @@ ul {
             <div>
             <div id="shapeMap-tabs" class="droparea" style="width: 100%">
               <ul>
-                <li><a href="#textMap">Query Map</a></li>
-                <li><a href="#editMap-tab">Query Map Editor</a></li>
-                <li><a href="#fixedMap-tab">Fixed Map</a></li>
+                <li><a href="#textMap">Query</a></li>
+                <li><a href="#fixedMap-tab">Entities to check</a></li>
               </ul>
               <!-- <div id="textMap-tab"> -->
                 <textarea id="textMap" style="width:100%; height:100%;"></textarea>


### PR DESCRIPTION
    Query Map Renamed to Query
    Fixed Map Renamed to Entities to check
Query Map Editor tab is removed

Bug: T221606