### PR TITLE
Removed control menu in shex simple tool

### DIFF
--- a/packages/shex-webapp/doc/shex-simple.html
+++ b/packages/shex-webapp/doc/shex-simple.html
@@ -128,7 +128,7 @@
         padding-right: .5em; /* for firefox rendering issue */
       }
 
-#menuForm > fieldset {
+#aboutForm > fieldset {
     box-shadow: -.3ex .3ex grey;
     display: inline;
 }
@@ -150,8 +150,8 @@
 #controls h3 {
     margin: 0;
 }
-#menu-button { margin-left: 1em; }
-#menu-button svg { width: 1em; height: 1.5ex; }
+#about-button { margin-left: 1em; }
+#about-button svg { width: 1em; height: 1.5ex; }
 #about {
   margin: 3em;
 }
@@ -227,8 +227,8 @@ ul {
       <!-- <ul id="navlist" style="float:left; padding-left: 1em;"> -->
       <!--   <li>‣ <span class="heading">drag and drop to:</span> <input type="file" id="schema-upload" class="inputfile" data-target="#inputSchema textarea"/> <label for="schema-upload" class="schema">ShEx schema</label>, <input type="file" id="meta-upload" class="inputfile" data-target="#meta textarea"/> <label for="meta-upload" class="meta">metadata</label>, <input type="file" id="data-upload" class="inputfile" data-target="#inputData textarea"/> <label for="data-upload" class="data">RDF data</label></li> -->
       <!-- </ul> -->
-      <form id="menuForm">
-          <button id="menu-button" title="click for menu">
+      <form id="aboutForm">
+          <button id="about-button">
             <div class="menuitem" id="about-button">About</div>
           </button>
       </form>

--- a/packages/shex-webapp/doc/shex-simple.html
+++ b/packages/shex-webapp/doc/shex-simple.html
@@ -229,33 +229,8 @@ ul {
       <!-- </ul> -->
       <form id="menuForm">
           <button id="menu-button" title="click for menu">
-            controls <svg><use xlink:href="#down-arrow"/><use xlink:href="#up-arrow" /></svg>
+            <div class="menuitem" id="about-button">About</div>
           </button>
-        <div id="controls">
-          <div>
-            <ul>
-              <li class="        "><h3>user interface</h3></li>
-              <li class="menuitem"><label for="interface">style:</label><select id="interface"><option value="minimal">minimal</option><option value="human">human</option><option value="appinfo">appinfo</option></select></li>
-              <li class="menuitem"><input type="checkbox" id="showMeta"/><label for="showMeta">show metadata pane</label></li>
-              <li class="menuitem"><a id="download-results-button">download <span class="results">results</span></a></li>
-              <li class="        "><hr/></li>
-              <li class="        "><h3>HTTP</h3></li>
-              <li class="menuitem" id="load-schema-button">load <span class="schema">schema</span></li>
-              <li class="menuitem" id="load-data-button">load <span class="data">data</span></li>
-              <li class="menuitem" id="load-manifest-button">load <span class="manifest">manifest</span></li>
-              <li class="        "><hr/></li>
-              <li class="        "><h3>drag and drop</h3></li>
-              <li class="menuitem"><input type="checkbox" id="append"/><label for="append">drop appends</label></li>
-              <li class="menuitem"><label for="duplicateShape">duplicate shape:</label><select id="duplicateShape"><option value="abort">abort</option><option value="replace">replace</option><option value="ignore">ignore</option></select></li>
-              <li class="        "><hr/></li>
-              <li class="        "><h3>performance</h3></li>
-              <li class="menuitem"><label for="regexpEngine">error reporting:</label><select id="regexpEngine"><option value="threaded-val-nerr">thorough</option><option value="nfax-val-1err">fast</option></select></li>
-              <li class="        "><hr/></li>
-              <li class="menuitem" id="permalink"><a>Permalink</a></li>
-              <li class="menuitem" id="about-button">About</li>
-            </ul>
-          </div>
-        </div>
       </form>
       <div id="loadForm" style="cursor: default; text-align: left; ">
         <h1>Load <span></span></h1>

--- a/packages/shex-webapp/doc/shex-simple.js
+++ b/packages/shex-webapp/doc/shex-simple.js
@@ -1185,7 +1185,7 @@ function removeEditMapPair (evt) {
 }
 
 function prepareControls () {
-  $("#menu-button").on("click", toggleControls);
+  $("#about-button").on("click", toggleControls);
   $("#interface").on("change", setInterface);
   $("#regexpEngine").on("change", toggleControls);
   $("#validate").on("click", disableResultsAndValidate);
@@ -1308,13 +1308,13 @@ function toggleControls (evt) {
     var target = evt.target;
     while (target.tagName !== "BUTTON")
       target = target.parentElement;
-    if ($("#menuForm").css("position") === "absolute") {
+    if ($("#aboutForm").css("position") === "absolute") {
       $("#controls").
         css("top", 0).
-        css("left", $("#menu-button").css("margin-left"));
+        css("left", $("#about-button").css("margin-left"));
     } else {
       var bottonBBox = target.getBoundingClientRect();
-      var controlsBBox = $("#menuForm").get(0).getBoundingClientRect();
+      var controlsBBox = $("#aboutForm").get(0).getBoundingClientRect();
       var left = bottonBBox.right - bottonBBox.width; // - controlsBBox.width;
       $("#controls").css("top", bottonBBox.bottom).css("left", left);
     }
@@ -1342,11 +1342,11 @@ function queryTracker () {
 
 function toggleControlsArrow (which) {
   // jQuery can't find() a prefixed attribute (xlink:href); fall back to DOM:
-  if (document.getElementById("menu-button") === null)
+  if (document.getElementById("about-button") === null)
     return;
-  var down = $(document.getElementById("menu-button").
+  var down = $(document.getElementById("about-button").
                querySelectorAll('use[*|href="#down-arrow"]'));
-  var up = $(document.getElementById("menu-button").
+  var up = $(document.getElementById("about-button").
              querySelectorAll('use[*|href="#up-arrow"]'));
 
   switch (which) {
@@ -1755,10 +1755,10 @@ function customizeInterface () {
     $("#inputData .status").html("data (<span id=\"dataDialect\">Turtle</span>)").show();
     $("#actions").parent().children().not("#actions").hide();
     $("#title img, #title h1").hide();
-    $("#menuForm").css("position", "absolute").css(
+    $("#aboutForm").css("position", "absolute").css(
       "left",
       $("#inputSchema .status").get(0).getBoundingClientRect().width -
-        $("#menuForm").get(0).getBoundingClientRect().width
+        $("#aboutForm").get(0).getBoundingClientRect().width
     );
     $("#controls").css("position", "relative");
   } else {
@@ -1766,7 +1766,7 @@ function customizeInterface () {
     $("#inputData .status").html("data (<span id=\"dataDialect\">Turtle</span>)").hide();
     $("#actions").parent().children().not("#actions").show();
     $("#title img, #title h1").show();
-    $("#menuForm").removeAttr("style");
+    $("#aboutForm").removeAttr("style");
     $("#controls").css("position", "absolute");
   }
 }


### PR DESCRIPTION
The control menu was removed and replaced by the about link as a button
see: https://phabricator.wikimedia.org/T221604