### PR TITLE
Update Input tabs in Shex tool

### DIFF
--- a/packages/shex-webapp/doc/shex-simple.html
+++ b/packages/shex-webapp/doc/shex-simple.html
@@ -312,8 +312,9 @@ ul {
             <div>
             <div id="shapeMap-tabs" class="droparea" style="width: 100%">
               <ul>
-                <li><a href="#textMap">Query</a></li>
-                <li><a href="#fixedMap-tab">Entities to check</a></li>
+                <li id="textMap-tab-header"><a href="#textMap">Query Map</a></li>
+                <li id="editMap-tab-header"><a href="#editMap-tab">Query Map Editor</a></li>
+                <li id="fixedMap-tab-header"><a href="#fixedMap-tab">Fixed Map</a></li>
               </ul>
               <!-- <div id="textMap-tab"> -->
                 <textarea id="textMap" style="width:100%; height:100%;" placeholder="&lt;SomeFocusNode&gt;@START"></textarea>

--- a/packages/shex-webapp/doc/shex-simple.js
+++ b/packages/shex-webapp/doc/shex-simple.js
@@ -1633,6 +1633,9 @@ function loadSearchParameters () {
     $("#textMap").data("isSparqlQuery", true)
       .attr("placeholder", "SELECT ?id WHERE {\n    # ...\n}");
     $("#validate .validate-label").text("run query to fetch entities");
+    $("textMap-tab-header a").text('Query');
+    $("#editMap-tab-header").remove();
+    $("#fixedMap-tab-header a").text('Entities to check');
   }
 
   // Load all known query parameters.
@@ -1719,7 +1722,7 @@ function loadSearchParameters () {
   });
 }
 
-  /**
+/**
    * update location with a current values of some inputs
    */
   function getPermalink () {


### PR DESCRIPTION
Updated the input tabs in the shex-simple.js fille such that it changes only when textMapIsSparqlQuery is set.
see commit #43