### PR TITLE
rename and remove query input tabs in shex simple tool

### DIFF
--- a/packages/shex-webapp/doc/shex-simple.html
+++ b/packages/shex-webapp/doc/shex-simple.html
@@ -312,9 +312,9 @@ ul {
             <div>
             <div id="shapeMap-tabs" class="droparea" style="width: 100%">
               <ul>
-                <li id="query"><a href="#textMap">Query Map</a></li>
-                <li id="queryEditor"><a href="#editMap-tab">Query Map Editor</a></li>
-                <li id="fixMap"><a href="#fixedMap-tab">Fixed Map</a></li>
+                <li id="textMap-tab-header"><a href="#textMap">Query Map</a></li>
+                <li id="editMap-tab-header"><a href="#editMap-tab">Query Map Editor</a></li>
+                <li id="fixedMap-tab-header"><a href="#fixedMap-tab">Fixed Map</a></li>
               </ul>
               <!-- <div id="textMap-tab"> -->
                 <textarea id="textMap" style="width:100%; height:100%;" placeholder="&lt;SomeFocusNode&gt;@START"></textarea>

--- a/packages/shex-webapp/doc/shex-simple.js
+++ b/packages/shex-webapp/doc/shex-simple.js
@@ -1633,7 +1633,9 @@ function loadSearchParameters () {
     $("#textMap").data("isSparqlQuery", true)
       .attr("placeholder", "SELECT ?id WHERE {\n    # ...\n}");
     $("#validate .validate-label").text("run query to fetch entities");
-    changeInputTabs();
+    $("textMap-tab-header a").text('Query');
+    $("#editMap-tab-header").remove();
+    $("#fixedMap-tab-header a").text('Entities to check');
   }
 
   // Load all known query parameters.
@@ -1718,12 +1720,6 @@ function loadSearchParameters () {
       }
     }
   });
-}
-
-function changeInputTabs() {
-  $("#query").html("<a href=\"#textMap\">Query</a>");
-  $("#queryEditor").remove();
-  $("#fixMap").html("<a href=\"#fixedMap-tab\">Entities to check</a>");
 }
 
   /**


### PR DESCRIPTION
pull request #46 reverted changes in #48. this commit adds the changes back.