### PR TITLE
- generated ShExJ

### DIFF
--- a/packages/shex-webapp/doc/shex-simple.js
+++ b/packages/shex-webapp/doc/shex-simple.js
@@ -881,31 +881,6 @@ function callValidator (done) {
       }
 
     } else {
-      var outputLanguage = Caches.inputSchema.language === "ShExJ" ? "ShExC" : "ShExJ";
-      $("#results .status").
-        text("parsed "+Caches.inputSchema.language+" schema, generated "+outputLanguage+" ").
-        append($("<button>(copy to input)</button>").
-               css("border-radius", ".5em").
-               on("click", function () {
-                 Caches.inputSchema.set($("#results div").text(), DefaultBase);
-               })).
-        append(":").
-        show();
-      var parsedSchema;
-      if (Caches.inputSchema.language === "ShExJ") {
-        new ShEx.Writer({simplifyParentheses: false}).writeSchema(Caches.inputSchema.parsed, (error, text) => {
-          if (error) {
-            $("#results .status").text("unwritable ShExJ schema:\n" + error).show();
-            // res.addClass("error");
-          } else {
-            results.append($("<pre/>").text(text).addClass("passes"));
-          }
-        });
-      } else {
-        var pre = $("<pre/>");
-        pre.text(JSON.stringify(ShEx.Util.AStoShExJ(ShEx.Util.canonicalize(Caches.inputSchema.parsed)), null, "  ")).addClass("passes");
-        results.append(pre);
-      }
       results.finish();
       if (done) { done() }
     }


### PR DESCRIPTION
When someone visits the tool from a schema on Wikidata – i. e., the schema text is already populated via the URL, but the shape map is not – then we don’t want to show them the parsed ShExJ.

Bug: [T221609](https://phabricator.wikimedia.org/T221609)

Something similar was also attempted in #46, but then reverted in efa4c32c199bb8565a68bd2cd4b3bfbd6519f3c8.