### PR TITLE
Fix inconsistent use of Maps

### DIFF
--- a/packages/shex-core/lib/ShExUtil.js
+++ b/packages/shex-core/lib/ShExUtil.js
@@ -565,8 +565,8 @@ var ShExUtil = {
    */
   index: function (schema) {
     let index = {
-      shapeExprs: new Map(),
-      tripleExprs: new Map()
+      shapeExprs: {},
+      tripleExprs: {}
     };
     let v = ShExUtil.Visitor();
 


### PR DESCRIPTION
`shapeExprs` and `tripleExprs` were declared to be [Maps](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map), but they're populated (and accessed throughout shex.js) with object properties - `index.tripleExprs[expression.id] = expression` just sets a regular object property. If you change it to actually set a map entry with `index.tripleExprs.set(expression.id, expression)` then you'll have to change all the usages of `index.tripleExprs[expr]` to `index.tripleExprs.get(expr)` and all the usages of `Object.keys(index.tripleExprs)` to use iterators like `index.tripleExprs.keys()` or `index.tripleExprs.entries()`, etc.

Maps are awesome and would be a good choice here but the refactor ended up touching more files than I was comfortable with... and there were a lot of decisions around how to handle iterators that I didn't want to make, so here's a tiny PR to switch the initializations to regular objects.