### PR TITLE
Allow blobs as a data source

### DIFF
--- a/packages/shex-loader/shex-loader.js
+++ b/packages/shex-loader/shex-loader.js
@@ -33,7 +33,7 @@ function GET (f, mediaType) {
       process.stdin.on("error", function (e) {
         reject(e);
       });
-    }) : (f.match("^[a-z]+://.") && !f.match("^file://.")) ?
+    }) : (f.match("^(blob:)?[a-z]+://.") && !f.match("^file://.")) ?
     // Read from http or whatever Request handles.
     myHttpRequest(f, mediaType) : (m = f.match("^data:([^,]+),(.*)$")) ?
     // Read from data: URL


### PR DESCRIPTION
Allows using not only http:// or https://, but also blob:http:// or blob:https://as remote sources for input files. Can be useful when the library is executed on the front-end side of some application when the source ShEx is only available as a string.