### PR TITLE
fix: make --extension flag functional for loading ShEx extensions

### DIFF
--- a/packages/shex-cli/bin/validate
+++ b/packages/shex-cli/bin/validate
@@ -740,7 +740,7 @@ async function runValidator (db, shapeMap, schema, options, cmds) {
   const validator = new ShExValidator(schema, db, options);
   const extensions = ShExNode.loadExtensions(cmds.extension);
   Object.keys(extensions).forEach(function (ext) {
-    extensions[ext].register(validator);
+    extensions[ext].register(validator, {ShExTerm});
   });
 
   if (cmds["dry-run"])

--- a/packages/shex-loader/shex-loader.js
+++ b/packages/shex-loader/shex-loader.js
@@ -81,7 +81,7 @@ const ShExLoaderCjsModule = function (config = {}) {
 
   const loader = {
     load: load,
-    loadExtensions: LoadNoExtensions,
+    loadExtensions: config.loadExtensions || LoadNoExtensions,
     GET,
     ResourceLoadControler,
     loadSchemaImports,

--- a/packages/shex-node/shex-node.js
+++ b/packages/shex-node/shex-node.js
@@ -99,17 +99,20 @@ const ShExNodeCjsModule = function (config = {}) {
   return newLoader
 
   function LoadExtensions (globs) {
+    const NodePath = require('path')
     return globs.reduce(
       (list, glob) =>
         list.concat(Glob.sync(glob))
       , []).
-      reduce(function (ret, path) {
+      reduce(function (ret, extPath) {
         try {
-	  const t = require(path)
+	  const absPath = NodePath.resolve(extPath)
+	  const rawModule = require(absPath)
+	  const t = typeof rawModule === 'function' ? rawModule(Object.assign({Validator: {}}, config)) : rawModule
 	  ret[t.url] = t
 	  return ret
         } catch (e) {
-	  console.warn("ShEx extension \"" + moduleDir + "\" not loadable: " + e)
+	  console.warn("ShEx extension \"" + extPath + "\" not loadable: " + e)
 	  return ret
         }
       }, {})


### PR DESCRIPTION
## Problem

`shex-validate --extension <glob>` silently failed to load any extensions due to four separate bugs across three packages.

## Fixes

### `packages/shex-loader`
`loadExtensions` was hardcoded to `LoadNoExtensions`, ignoring the `config.loadExtensions` function passed in by `@shexjs/node`:
```js
// before
loadExtensions: LoadNoExtensions,
// after
loadExtensions: config.loadExtensions || LoadNoExtensions,
```

### `packages/shex-node` (3 bugs)

1. **Path resolution** — `require(path)` fails for relative paths like `node_modules/foo/bar.js` that do not start with `./`. Fixed by resolving to an absolute path first with `NodePath.resolve(extPath)`.

2. **Factory modules** — extension modules (e.g. `@shexjs/extension-map`) export a factory function, not a plain object. `LoadExtensions` called `require()` but never invoked the factory. Fixed by detecting function exports and calling them with the node config (`Object.assign({Validator: {}}, config)`).

3. **Error message** — the `catch` block referenced undefined `moduleDir` instead of the loop variable. Fixed to use `extPath`.

### `packages/shex-cli`

`validate` called `extensions[ext].register(validator)` but `register(validator, api)` requires a second argument containing `{ShExTerm}`. `ShExTerm` is already imported at the top of `validate`. Fixed by passing `{ShExTerm}` as the second argument.

## Verification

After these fixes, the following pipeline works end-to-end:

```bash
shex-validate -x bpfhir.shex -d bpfhir.ttl -n tag:BPfhir123   --extension node_modules/@shexjs/extension-map/shex-extension-map.js   | shexmap-materialize -t bpdam.shex
```

Output:
```turtle
<tag:eric@w3.org/2016/root> <http://dam.example/med#name> "Walker, Alice";
    <http://dam.example/med#systolic> _:b0;
    <http://dam.example/med#diastolic> _:b1.
_:b0 <http://dam.example/med#value> "110"^^<http://www.w3.org/2001/XMLSchema#float>;
    <http://dam.example/med#units> "mmHg".
_:b1 <http://dam.example/med#value> "70"^^<http://www.w3.org/2001/XMLSchema#float>;
    <http://dam.example/med#units> "mmHg".
```
