### PR TITLE
types: improve .d.ts declarations for shex-loader and shex-node

### DIFF
--- a/packages/shex-loader/shex-loader.d.ts
+++ b/packages/shex-loader/shex-loader.d.ts
@@ -1,5 +1,92 @@
-export = shexjs__loader;
+export = ShExLoader;
 
-declare function shexjs__loader(config: any): any;
+declare function ShExLoader(config?: ShExLoader.Config): ShExLoader.Loader;
 
+declare namespace ShExLoader {
 
+  /** A loaded ShEx extension (e.g. @shexjs/extension-map). */
+  interface ShExExtension {
+    url: string;
+    register(validator: any, api: { ShExTerm: any }): void;
+    done(validator: any): void;
+  }
+
+  /** Result of a GET request. */
+  interface LoadedResource {
+    text: string;
+    url: string;
+  }
+
+  /** Result of a load() call. */
+  interface LoadResult {
+    schema: any;
+    data: any;
+    schemaMeta: any[];
+    dataMeta: any[];
+  }
+
+  /** Schema inputs accepted by load(). */
+  interface SchemaInput {
+    shexc?: Array<string | { url: string; text?: string }>;
+    json?:  Array<string | { url: string; text?: string }>;
+    turtle?: Array<string | { url: string; text?: string }>;
+  }
+
+  /** Data inputs accepted by load(). */
+  interface DataInput {
+    turtle?: Array<string | { url: string; text?: string }>;
+    jsonld?: Array<string | { url: string; text?: string }>;
+  }
+
+  /** Configuration passed to the ShExLoader factory. */
+  interface Config {
+    /** Override the default no-op extension loader. */
+    loadExtensions?: (globs: string[]) => Record<string, ShExExtension>;
+    /** HTTP fetch implementation (e.g. node-fetch). */
+    fetch?: (url: string, options?: any) => Promise<any>;
+    /** RDF/JS DataFactory + Store implementation (e.g. N3). */
+    rdfjs?: any;
+    /** jsonld library instance. */
+    jsonld?: any;
+    /** Options forwarded to jsonld.toRDF(). */
+    jsonLdOptions?: any;
+  }
+
+  class WebError extends Error {
+    url: string;
+    constructor(msg: string, url: string);
+  }
+
+  class FetchError extends WebError {
+    status: number;
+    text: string;
+    constructor(msg: string, url: string, status: number, text: string);
+  }
+
+  /** The object returned by the ShExLoader factory. */
+  interface Loader {
+    load(
+      schema: SchemaInput | null,
+      data: DataInput | null,
+      schemaOptions?: any,
+      dataOptions?: any,
+    ): Promise<LoadResult>;
+
+    /** Load ShEx validator extensions matching the given globs. */
+    loadExtensions(globs: string[]): Record<string, ShExExtension>;
+
+    /** Fetch a URL, returning its text content and resolved URL. */
+    GET(url: string, mediaType?: string): Promise<LoadedResource>;
+
+    loadSchemaImports(
+      schema: any,
+      importers: string[],
+      resourceLoadControler: any,
+      schemaOptions?: any,
+    ): any;
+
+    ResourceLoadControler: any;
+    WebError: typeof WebError;
+    FetchError: typeof FetchError;
+  }
+}

--- a/packages/shex-node/shex-node.d.ts
+++ b/packages/shex-node/shex-node.d.ts
@@ -1,5 +1,20 @@
-export = shexjs__node;
+import ShExLoader = require("@shexjs/loader");
 
-declare function shexjs__node(config: any): any;
+export = ShExNode;
 
+/**
+ * Extends @shexjs/loader with:
+ * - `file:` URL and filesystem path support
+ * - stdin (`-`) support
+ * - Dynamic loading of ShEx extensions via loadExtensions()
+ */
+declare function ShExNode(config?: ShExNode.Config): ShExLoader.Loader;
 
+declare namespace ShExNode {
+
+  /** ShExNode config extends ShExLoader.Config with Node.js-specific options. */
+  interface Config extends ShExLoader.Config {
+    /** Working directory used to resolve relative file paths. */
+    cwd?: string;
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the placeholder `(config: any): any` stubs in `shex-loader.d.ts` and `shex-node.d.ts` with properly typed declarations derived from the JS source.

### `@shexjs/loader`

New interfaces:
- **`Config`** — `fetch`, `rdfjs`, `jsonld`, `jsonLdOptions`, `loadExtensions`
- **`ShExExtension`** — `url`, `register(validator, {ShExTerm})`, `done`
- **`SchemaInput`** / **`DataInput`** — inputs accepted by `load()`
- **`LoadResult`** — return value of `load()`
- **`LoadedResource`** — return value of `GET()`
- **`Loader`** — the full object returned by the factory: `load`, `loadExtensions`, `GET`, `loadSchemaImports`, `ResourceLoadControler`, `WebError`, `FetchError`
- **`WebError`** / **`FetchError`** class declarations

### `@shexjs/node`

- Imports and reuses `ShExLoader.Loader` as the return type — `shex-node` wraps `shex-loader` and returns the same `Loader` interface with an enhanced `GET`
- **`Config`** extends `ShExLoader.Config` adding the optional `cwd` field

## Related

Companion to #420 which fixes the runtime bugs that prevented `--extension` from working.
